### PR TITLE
Add tab scrolling for macrotags (books)

### DIFF
--- a/foolscap/actor.py
+++ b/foolscap/actor.py
@@ -58,7 +58,7 @@ def action(do_action, arg, list_type='notes', book='general'):
 
     func = FUNCTION_MAP[do_action]
 
-    new_action = None
+    new_action = {}
     if do_action in DISPLAY_ACTIONS:
         display_ctrl = Controller(list_type)
 
@@ -72,9 +72,13 @@ def action(do_action, arg, list_type='notes', book='general'):
         else:
             new_action = display_ctrl.basic_output(book)
 
-    if new_action:
-        new_func, note = new_action
-        action(new_func, note)
+    if new_action.get('action', False):
+        new_func = new_action['action']
+        note = new_action['item']
+        if new_func == 'list':
+            action(new_func, None, book=new_action['book'])
+        else:
+            action(new_func, note)
     # arg is note in this case
     elif arg:
         func(arg)

--- a/foolscap/display/key_listener.py
+++ b/foolscap/display/key_listener.py
@@ -67,6 +67,10 @@ class KeyListener:
             self.command = 'help'
         elif key == RIGHT_ARROW:
             self.command = 'expand'
+        elif key == ord('l'):
+            self.command = 'next_tab'
+        elif key == ord('h'):
+            self.command = 'prev_tab'
         return self.command, self.scroll.list_pointer
 
     def get_position(self):

--- a/foolscap/display/menu.py
+++ b/foolscap/display/menu.py
@@ -21,10 +21,15 @@ def _set_colour(line, cursor):
 class MenuAdapter:
     """This object holds all the items in the list."""
 
-    def __init__(self, items):
+    def __init__(self, items, model):
         """Get the data into the correct format.
         This should be handled before this"""
-        self.menu = [MenuItem(**item) for item in items]
+        self.menu = [
+            MenuItem(**{
+                'title': item,
+                'model': model
+            }) for item in items
+        ]
 
     @property
     def length(self):
@@ -56,11 +61,10 @@ class MenuAdapter:
 class DisplayMenu(Widget):
     """This object is responsible for displaying the menu."""
 
-    def __init__(self, screen, items):
-        model_type = items[0]['model'].model_type
-        self.menu = MenuAdapter(items)
+    def __init__(self, screen, items, model):
+        self.menu = MenuAdapter(items, model)
         #: available columns
-        self.columns = Columns(model_type)
+        self.columns = Columns(model)
         self.columns.attach_screen(screen)
         self.attach_screen(screen)
 

--- a/foolscap/note_display.py
+++ b/foolscap/note_display.py
@@ -12,21 +12,22 @@ class Controller:
             self.model = TagsModel(self.model)
         self.service_rules = ServiceRules(self.model)
 
-    def __service_rules(self, items):
+    def __service_rules(self, items, tab_title):
         items = self.service_rules.order(items)
         structure = self.service_rules.structure(items)
+        structure['tab_title'] = tab_title
         return display_list(structure)
 
     def basic_output(self, book):
         items = list(self.model)
         self.items = self.service_rules.filter_items(items, book)
-        return self.__service_rules(self.items)
+        return self.__service_rules(self.items, book)
 
     def query_output(self, query):
         items = self.model.query_tags(query)
         if not items:
             exit()
-        return self.__service_rules(items)
+        return self.__service_rules(items, "tag: '{}'".format(query))
 
     def search_output(self, query):
         if not query:
@@ -36,6 +37,7 @@ class Controller:
         if not items:
             exit()
         structure = self.service_rules.structure(items)
+        structure['tab_title'] = 'search'
         return display_list(structure)
 
 
@@ -114,10 +116,8 @@ class ServiceRules:
                       reverse=True)
 
     def structure(self, iterable):
-        return [
-            {
-                'title': item,
-                'model': self.model,
-            }
-            for item in iterable
-        ]
+        return {
+            'titles': [item for item in iterable],
+            'model': self.model,
+            'books': self.model.books,
+        }

--- a/tests/test_actor.py
+++ b/tests/test_actor.py
@@ -17,13 +17,13 @@ class MockCtrl:
         self.model_type = model_type
 
     def basic_output(self):
-        return  'view', 'note'
+        return 'view', 'note'
 
     def query_output(self, query):
-        return  'view', 'note'
+        return 'view', 'note'
 
     def search_output(self, query):
-        return  'view', 'note'
+        return 'view', 'note'
 
 
 def test_save_note_command():
@@ -73,9 +73,12 @@ def test_search_note(query, expected):
     mock_view = MagicMock()
     mock_ctrl = MagicMock()
     # Have to return view so that we can exit
-    mock_ctrl.return_value.search_output.return_value = ('view', 'mock_note')
+    mock_ctrl.return_value.search_output.return_value = {
+        'action': 'view',
+        'item': 'mock_note',
+    }
     with patch.dict('foolscap.actor.FUNCTION_MAP', {'view': mock_view}),\
-         patch('foolscap.actor.Controller', mock_ctrl):
+            patch('foolscap.actor.Controller', mock_ctrl):
 
         # Pass to actor:
         actor.action('search', query)
@@ -88,23 +91,28 @@ def test_list_note_command_no_tags():
     mock_view = MagicMock()
     mock_ctrl = MagicMock()
     # Have to return view so that we can exit
-    mock_ctrl.return_value.basic_output.return_value = ('view', 'mock_note')
+    mock_ctrl.return_value.basic_output.return_value = {
+        'action': 'view',
+        'item': 'mock_note',
+    }
     with patch.dict('foolscap.actor.FUNCTION_MAP', {'view': mock_view}),\
-         patch('foolscap.actor.Controller', mock_ctrl):
+            patch('foolscap.actor.Controller', mock_ctrl):
 
         # Pass to actor:
         actor.action('list', None)
         mock_ctrl.return_value.basic_output.assert_called()
 
 
-
 def test_list_note_command_returning_func():
     mock_view = MagicMock()
     mock_ctrl = MagicMock()
     # Have to return view so that we can exit
-    mock_ctrl.return_value.query_output.return_value = ('view', 'mock_note')
+    mock_ctrl.return_value.query_output.return_value = {
+        'action': 'view',
+        'item': 'mock_note',
+    }
     with patch.dict('foolscap.actor.FUNCTION_MAP', {'view': mock_view}),\
-         patch('foolscap.actor.Controller', mock_ctrl):
+            patch('foolscap.actor.Controller', mock_ctrl):
 
         expected_view = call('mock_note')
 
@@ -182,9 +190,12 @@ def test_change_list_type():
     mock_view = MagicMock()
     mock_ctrl = MagicMock()
     # Have to return view so that we can exit
-    mock_ctrl.return_value.basic_output.return_value = ('view', 'note')
+    mock_ctrl.return_value.basic_output.return_value = {
+        'action': 'view',
+        'item': 'note',
+    }
     with patch.dict('foolscap.actor.FUNCTION_MAP', {'view': mock_view}),\
-         patch('foolscap.actor.Controller', mock_ctrl):
+            patch('foolscap.actor.Controller', mock_ctrl):
 
         actor.action('list', None, 'tags')
         mock_ctrl.assert_called_with('tags')

--- a/tests/test_actor.py
+++ b/tests/test_actor.py
@@ -186,6 +186,35 @@ def test_all_actions():
     assert set(ACTIONS) == set(TESTED_ACTIONS)
 
 
+def test_change_book():
+    """Test that book can change."""
+    mock_view = MagicMock()
+    mock_ctrl = MagicMock()
+    # Have to return view so that we can exit
+    mock_ctrl.return_value.basic_output.side_effect = [
+        {
+            'action': 'list',
+            'item': 'note',
+            'book': 'mock_book',
+        },
+        {
+            'action': 'view',
+            'item': 'note',
+        }
+    ]
+
+    mock_functions = {
+        'view': mock_view,
+        'list': None,
+    }
+    with patch.dict('foolscap.actor.FUNCTION_MAP', mock_functions),\
+            patch('foolscap.actor.Controller', mock_ctrl):
+
+        actor.action('list', None)
+        mock_ctrl.has_calls(calls=[call('general'), call('mock_book')])
+        mock_ctrl.return_value.basic_output.assert_called()
+
+
 def test_change_list_type():
     mock_view = MagicMock()
     mock_ctrl = MagicMock()

--- a/tests/test_display/menu_objects_test.py
+++ b/tests/test_display/menu_objects_test.py
@@ -16,10 +16,10 @@ from tests.data.mock_meta_data import FAKE_FOUR_NOTES_W_SUB
 Setup Test Fixtures:
 """
 
+
 @pytest.fixture(scope='function')
-def model_items():
+def display_data():
     from foolscap.meta_data import NotesModel
-    from foolscap.note_display import Controller
     from foolscap.note_display import ServiceRules
 
     patch_load = 'foolscap.meta_data.models.load_meta'
@@ -33,10 +33,9 @@ def model_items():
 
 
 @pytest.fixture(scope='function')
-def tag_items():
+def tag_data():
     from foolscap.meta_data import NotesModel
     from foolscap.meta_data import TagsModel
-    from foolscap.note_display import Controller
     from foolscap.note_display import ServiceRules
 
     patch_load = 'foolscap.meta_data.models.load_meta'
@@ -177,13 +176,19 @@ def test_MenuItem_init():
     assert not hasattr(item, 'expand')
 
 
-def test_MenuItem_NotesModel_init(model_items):
-    item = MenuItem(**model_items[0])
+def test_MenuItem_NotesModel_init(display_data):
+    item = MenuItem(**{
+        'title': display_data['titles'][0],
+        'model': display_data['model'],
+    })
     assert item.title == 'A'
 
 
-def test_MenuItem_TagModel_init(tag_items):
-    item = MenuItem(**tag_items[0])
+def test_MenuItem_TagModel_init(tag_data):
+    item = MenuItem(**{
+        'title': tag_data['titles'][0],
+        'model': tag_data['model'],
+    })
     assert item.title == 'fake_tag'
     assert item.raw_title == 'fake_tag'
 
@@ -211,8 +216,8 @@ def test_MenuItem_toggle():
     mock_model = {'description': 'that', 'sub_headings': mock_sub}
     mock_item = {'title': 'This', 'model': mock_model}
     item = MenuItem(**mock_item)
-    assert item.expand == False
+    assert item.expand is False
     item.toggle_drop_down()
-    assert item.expand == True
+    assert item.expand is True
     item.toggle_drop_down()
-    assert item.expand == False
+    assert item.expand is False

--- a/tests/test_display/test_console.py
+++ b/tests/test_display/test_console.py
@@ -1,7 +1,5 @@
-import pytest
 from mock import call
 from mock import patch
-from mock import Mock
 from mock import MagicMock
 
 from foolscap.display.console import display_list
@@ -9,24 +7,18 @@ from foolscap.display.console import setup_folio
 from foolscap.display.console import FolioConsole
 
 mock_model = MagicMock()
-FAKE_ITEMS = [
-    {
-        'title': "test_title",
-        'description': "test description",
-        'model': mock_model,
-    },
-    {
-        'title': "another_title",
-        'description': "another description",
-        'model': mock_model,
-    },
-]
+FAKE_ITEMS = {
+    'titles': ["test_title", "another_title"],
+    'model': mock_model,
+    'books': ['general'],
+    'tab_title': 'general',
+}
 
 
 def test_display_list():
     with patch('foolscap.display.console.setup_folio', 'func()'),\
-         patch('foolscap.display.console.curses') as mock_curses:
-        result = display_list('fake_data')
+            patch('foolscap.display.console.curses') as mock_curses:
+        display_list('fake_data')
         mock_curses.wrapper.assert_called_with('func()', 'fake_data')
 
 
@@ -34,13 +26,13 @@ def test_setup_folio():
     mock_screen = MagicMock()
     fake_data = FAKE_ITEMS
     with patch('foolscap.display.console.FolioConsole') as mock_folio,\
-         patch('foolscap.display.console.curses') as mock_curses:
+            patch('foolscap.display.console.curses') as mock_curses:
         calls = [call(mock_screen, FAKE_ITEMS),
                  call().__enter__(),
                  call().__enter__().show(),
                  call().__exit__(None, None, None)]
 
-        result = setup_folio(mock_screen, fake_data)
+        setup_folio(mock_screen, fake_data)
         mock_curses.curs_set.assert_called_with(0)
         assert mock_folio.mock_calls == calls
 
@@ -48,10 +40,10 @@ def test_setup_folio():
 def test_FolioConsole_contextmanager():
     two_calls = [call(), call()]
     mock_screen = MagicMock()
-    mock_screen.subwin(0,0).getmaxyx.return_value = 100, 100
+    mock_screen.subwin(0, 0).getmaxyx.return_value = 100, 100
     with patch('foolscap.display.console.panel') as mock_panel,\
-         patch('foolscap.display.console.curses') as mock_curses:
-        with FolioConsole(mock_screen, FAKE_ITEMS) as folio_console:
+            patch('foolscap.display.console.curses') as mock_curses:
+        with FolioConsole(mock_screen, FAKE_ITEMS):
             mock_screen.subwin().keypad.assert_called_once()
             mock_screen.subwin().clear.assert_called_once()
 
@@ -66,24 +58,26 @@ def test_FolioConsole_contextmanager():
         mock_curses.doupdate.assert_called_once()
 
 
-
 @patch('foolscap.display.console.Frame')
 @patch('foolscap.display.console.HelpBar')
 @patch('foolscap.display.console.StatusBar')
 @patch('foolscap.display.console.TitleBar')
 @patch('foolscap.display.console.DisplayMenu')
+@patch('foolscap.display.console.TabBar')
 @patch('foolscap.display.console.KeyListener')
-def test_FolioConsole_init(mock_keys, mock_display_menu, mock_titlebar,
-                           mock_statusbar, mock_helpbar, mock_frame):
+def test_FolioConsole_init(mock_keys, mock_tab, mock_display_menu,
+                           mock_titlebar, mock_statusbar, mock_helpbar,
+                           mock_frame):
     mock_screen = MagicMock()
     mock_screen.getmaxyx.return_value = 100, 100
-    with patch('foolscap.display.console.panel') as mock_panel,\
-         patch('foolscap.display.console.curses') as mock_curses:
+    with patch('foolscap.display.console.panel'),\
+            patch('foolscap.display.console.curses'):
         mocked_render_objects = [
             mock_frame(),
             mock_statusbar(),
             mock_titlebar(),
             mock_helpbar(),
+            mock_tab(),
             mock_display_menu(),
         ]
 
@@ -98,17 +92,20 @@ def test_FolioConsole_init(mock_keys, mock_display_menu, mock_titlebar,
         assert hasattr(test_console, 'menu')
         assert hasattr(test_console, 'key_listener')
 
-        assert test_console.items == FAKE_ITEMS
+        assert test_console.items == FAKE_ITEMS['titles']
         assert test_console.count_notes == 2
         assert test_console.render_objects == mocked_render_objects
-        assert len(test_console.render_objects) == 5
+        assert len(test_console.render_objects) == 6
         assert test_console.key_listener == mock_keys()
 
         mock_frame.assert_called_with(mock_screen.subwin())
         mock_statusbar.assert_called_with(mock_screen.subwin(), 2)
         mock_titlebar.assert_called_with(mock_screen.subwin())
         mock_helpbar.assert_called_with(mock_screen.subwin())
-        mock_display_menu.assert_called_with(mock_screen.subwin(), FAKE_ITEMS)
+        mock_tab.assert_called_with(
+            mock_screen.subwin(), 'general', ['general'])
+        mock_display_menu.assert_called_with(
+            mock_screen.subwin(), FAKE_ITEMS['titles'], FAKE_ITEMS['model'])
 
 
 @patch('foolscap.display.console.Frame')
@@ -116,18 +113,23 @@ def test_FolioConsole_init(mock_keys, mock_display_menu, mock_titlebar,
 @patch('foolscap.display.console.StatusBar')
 @patch('foolscap.display.console.TitleBar')
 @patch('foolscap.display.console.DisplayMenu')
+@patch('foolscap.display.console.TabBar')
 @patch('foolscap.display.console.KeyListener')
-def test_FolioConsole_render(mock_listener, mock_display_menu, mock_titlebar,
-                           mock_statusbar, mock_helpbar, mock_frame):
+def test_FolioConsole_render(mock_listener, mock_tab, mock_display_menu,
+                             mock_titlebar, mock_statusbar, mock_helpbar,
+                             mock_frame):
+    """Test that render objects are updated and drawn."""
     mock_screen = MagicMock()
     mock_screen.getmaxyx.return_value = 100, 100
-    with patch('foolscap.display.console.panel') as mock_panel,\
-         patch('foolscap.display.console.curses') as mock_curses:
+    with patch('foolscap.display.console.panel'),\
+            patch('foolscap.display.console.curses'):
+
         mocked_render_objects = [
             mock_frame(),
             mock_statusbar(),
             mock_titlebar(),
             mock_helpbar(),
+            mock_tab(),
             mock_display_menu(),
         ]
 
@@ -144,19 +146,15 @@ def test_FolioConsole_render(mock_listener, mock_display_menu, mock_titlebar,
 @patch('foolscap.display.console.StatusBar')
 @patch('foolscap.display.console.TitleBar')
 @patch('foolscap.display.console.DisplayMenu')
+@patch('foolscap.display.console.TabBar')
 @patch('foolscap.display.console.KeyListener')
-def test_FolioConsole_show(mock_listener, mock_display_menu, mock_titlebar,
-                           mock_statusbar, mock_helpbar, mock_frame):
+def test_FolioConsole_show(mock_listener, mock_tab, mock_display_menu,
+                           mock_titlebar, mock_statusbar, mock_helpbar,
+                           mock_frame):
     mock_screen = MagicMock()
-    with patch('foolscap.display.console.panel') as mock_panel,\
-         patch('foolscap.display.console.curses') as mock_curses:
-        mocked_render_objects = [
-            mock_frame(),
-            mock_statusbar(),
-            mock_titlebar(),
-            mock_helpbar(),
-            mock_display_menu(),
-        ]
+    with patch('foolscap.display.console.panel'),\
+            patch('foolscap.display.console.curses'):
+
         test_console = FolioConsole(mock_screen, FAKE_ITEMS)
         with patch.object(test_console, 'key_listener') as mocked_listener:
             mock_position = (0, 1)
@@ -165,8 +163,13 @@ def test_FolioConsole_show(mock_listener, mock_display_menu, mock_titlebar,
             mock_display_menu().select_item.return_value = 'selected_note'
 
             result = test_console.show()
-            mock_display_menu().update_pointers.assert_called_with(mock_position[0], mock_position[1])
-            assert result == ('action', 'selected_note')
+            mock_display_menu().update_pointers.assert_called_with(
+                mock_position[0], mock_position[1])
+            assert result == {
+                'action': 'action',
+                'index': 1,
+                'item': 'selected_note'
+            }
 
 
 @patch('foolscap.display.console.Frame')
@@ -174,27 +177,25 @@ def test_FolioConsole_show(mock_listener, mock_display_menu, mock_titlebar,
 @patch('foolscap.display.console.StatusBar')
 @patch('foolscap.display.console.TitleBar')
 @patch('foolscap.display.console.DisplayMenu')
+@patch('foolscap.display.console.TabBar')
 @patch('foolscap.display.console.KeyListener')
-def test_FolioConsole_expand_item(mock_listener, mock_display_menu, mock_titlebar,
-                           mock_statusbar, mock_helpbar, mock_frame):
+def test_FolioConsole_expand_item(mock_listener, mock_tab, mock_display_menu,
+                                  mock_titlebar, mock_statusbar, mock_helpbar,
+                                  mock_frame):
     mock_screen = MagicMock()
-    with patch('foolscap.display.console.panel') as mock_panel,\
-         patch('foolscap.display.console.curses') as mock_curses:
-        mocked_render_objects = [
-            mock_frame(),
-            mock_statusbar(),
-            mock_titlebar(),
-            mock_helpbar(),
-            mock_display_menu(),
-        ]
+    with patch('foolscap.display.console.panel'),\
+            patch('foolscap.display.console.curses'):
+
         test_console = FolioConsole(mock_screen, FAKE_ITEMS)
         with patch.object(test_console, 'key_listener') as mocked_listener:
             mock_position = (0, 1)
             mocked_listener.get_position.return_value = mock_position
-            mocked_listener.get_action.side_effect = [('expand', 1), ('action', 1)]
+            mocked_listener.get_action.side_effect = [
+                ('expand', 1), ('action', 1)
+            ]
             mock_display_menu().select_item.return_value = 'selected_note'
 
-            result = test_console.show()
+            test_console.show()
             assert test_console.menu.expand_item.call_args_list == [call(1)]
             test_console.menu.expand_item.assert_called_once()
 
@@ -204,26 +205,24 @@ def test_FolioConsole_expand_item(mock_listener, mock_display_menu, mock_titleba
 @patch('foolscap.display.console.StatusBar')
 @patch('foolscap.display.console.TitleBar')
 @patch('foolscap.display.console.DisplayMenu')
+@patch('foolscap.display.console.TabBar')
 @patch('foolscap.display.console.KeyListener')
-def test_FolioConsole_show_help(mock_listener, mock_display_menu, mock_titlebar,
-                           mock_statusbar, mock_helpbar, mock_frame):
+def test_FolioConsole_show_help(mock_listener, mock_tab, mock_display_menu,
+                                mock_titlebar, mock_statusbar, mock_helpbar,
+                                mock_frame):
     mock_screen = MagicMock()
-    with patch('foolscap.display.console.panel') as mock_panel,\
-         patch('foolscap.display.console.curses') as mock_curses:
-        mocked_render_objects = [
-            mock_frame(),
-            mock_statusbar(),
-            mock_titlebar(),
-            mock_helpbar(),
-            mock_display_menu(),
-        ]
+    with patch('foolscap.display.console.panel'),\
+            patch('foolscap.display.console.curses'):
+
         test_console = FolioConsole(mock_screen, FAKE_ITEMS)
         with patch.object(test_console, 'key_listener') as mocked_listener:
             mock_position = (0, 1)
             mocked_listener.get_position.return_value = mock_position
-            mocked_listener.get_action.side_effect = [('help', 1), ('action', 1)]
+            mocked_listener.get_action.side_effect = [
+                ('help', 1), ('action', 1)
+            ]
             mock_display_menu().select_item.return_value = 'selected_note'
 
-            result = test_console.show()
+            test_console.show()
             assert test_console.help_bar.next_hint.call_args_list == [call()]
             test_console.help_bar.next_hint.assert_called_once()

--- a/tests/test_display/test_key_listener.py
+++ b/tests/test_display/test_key_listener.py
@@ -33,6 +33,8 @@ def test_KeyListener_setmax():
      (ord('H'), ('help', 5)),
      (ord('g'), (None, 1)),
      (ord('G'), (None, 9)),
+     (ord('l'), ('next_tab', 5)),
+     (ord('h'), ('prev_tab', 5)),
      ('UP_ARROW', (None, 4)),
      ('DOWN_ARROW', (None, 6)),
      ('RIGHT_ARROW', ('expand', 5))])

--- a/tests/test_note_display.py
+++ b/tests/test_note_display.py
@@ -58,37 +58,44 @@ def test_controller__init__(note_model_init):
 
 
 @pytest.mark.parametrize("note_model, model_type, expected", [
-    (FAKE_MANY_NOTES, 'tags', [
-        {'title': 'fake_tag'},
-    ]),
-    (FAKE_MANY_NOTES, 'notes', [
-        {'title': 'recently_opened'},
-        {'title': 'most_viewed'},
-        {'title': 'second_most'},
-        {'title': 'third_most'},
-        {'title': 'A'},
-        {'title': 'fake_note_1'},
-        {'title': 'Z'},
-    ]),
-    (FAKE_SINGLE_NOTE_2, 'notes', [
-        {'title': 'most_viewed'}
-    ]),
-    (FAKE_SINGLE_NOTE, 'tags', [
-        {'title': 'fake_tag'}
-    ]),
-    (FAKE_SINGLE_NOTE, 'notes', [
-        {'title': 'most_viewed'},
-    ])],
+    (FAKE_MANY_NOTES, 'tags', {
+        'titles': ['fake_tag'],
+        'books': ['general'] * 7,
+    }),
+    (FAKE_MANY_NOTES, 'notes', {
+        'titles': [
+            'recently_opened',
+            'most_viewed',
+            'second_most',
+            'third_most',
+            'A',
+            'fake_note_1',
+            'Z',
+        ],
+        'books': ['general'] * 7,
+    }),
+    (FAKE_SINGLE_NOTE_2, 'notes', {
+        'titles': ['most_viewed'],
+        'books': ['general'],
+    }),
+    (FAKE_SINGLE_NOTE, 'tags', {
+        'titles': ['fake_tag'],
+        'books': ['general'],
+    }),
+    (FAKE_SINGLE_NOTE, 'notes', {
+        'titles': ['most_viewed'],
+        'books': ['general'],
+    })],
     indirect=['note_model'])
 def test_ctrl_basic_out(note_model, model_type, expected):
+    expected['tab_title'] = 'general'
     with patch('foolscap.note_display.display_list') as _mock:
         ctrl = Controller(model_type)
         ctrl.model = note_model
+        expected['model'] = note_model
         if model_type == 'tags':
             ctrl.model = TagsModel(note_model)
-
-        for item in expected:
-            item['model'] = ctrl.model
+            expected['model'] = ctrl.model
 
         ctrl.service_rules = ServiceRules(ctrl.model)
         ctrl.basic_output('general')
@@ -96,38 +103,47 @@ def test_ctrl_basic_out(note_model, model_type, expected):
 
 
 @pytest.mark.parametrize("note_model, model_type, query, expected", [
-    (FAKE_MANY_NOTES, 'tags', 'fake_tag', [
-        {'title': 'fake_tag'},
-    ]),
-    (FAKE_MANY_NOTES, 'notes', 'fake_tag', [
-        {'title': 'recently_opened'},
-        {'title': 'most_viewed'},
-        {'title': 'second_most'},
-        {'title': 'third_most'},
-        {'title': 'A'},
-        {'title': 'fake_note_1'},
-        {'title': 'Z'},
-    ]),
+    (FAKE_MANY_NOTES, 'tags', 'fake_tag', {
+        'titles': ['fake_tag'],
+        'books': ['general'] * 7,
+    },
+    ),
+    (FAKE_MANY_NOTES, 'notes', 'fake_tag', {
+        'titles': [
+            'recently_opened',
+            'most_viewed',
+            'second_most',
+            'third_most',
+            'A',
+            'fake_note_1',
+            'Z',
+        ],
+        'books': ['general'] * 7,
+    }),
     # None passed to query - should not happen. This is controlled by
     # Actor
-    (FAKE_SINGLE_NOTE, 'tags', 'fake_tag', [
-        {'title': 'fake_tag'}
-    ]),
-    (FAKE_SINGLE_NOTE, 'notes', 'fake_tag', [
-        {'title': 'most_viewed'},
-    ])],
+    (FAKE_SINGLE_NOTE, 'tags', 'fake_tag', {
+        'titles': ['fake_tag'],
+        'books': ['general'],
+    }
+    ),
+    (FAKE_SINGLE_NOTE, 'notes', 'fake_tag', {
+        'titles': ['most_viewed'],
+        'books': ['general'],
+    }
+    )],
     indirect=['note_model'])
 def test_ctrl_query_out(note_model, model_type, query, expected):
+    expected['tab_title'] = "tag: '{}'".format(query)
     with patch('foolscap.note_display.display_list') as _mock:
         ctrl = Controller(model_type)
         ctrl.model = note_model
+        expected['model'] = note_model
         if model_type == 'tags':
             ctrl.model = TagsModel(note_model)
+            expected['model'] = ctrl.model
+
         ctrl.service_rules = ServiceRules(ctrl.model)
-
-        for item in expected:
-            item['model'] = ctrl.model
-
         ctrl.query_output(query)
         _mock.assert_called_with(expected)
 
@@ -149,24 +165,31 @@ def test_ctrl_with_no_tag_matches(note_model, model_type):
 
 
 @pytest.mark.parametrize("note_model, model_type, query, expected", [
-    (FAKE_MANY_NOTES, 'tags', 'fake', [
-        {'title': 'fake_tag'}
-    ]),
-    (FAKE_MANY_NOTES, 'notes', 'most', [
-        {'title': 'most_viewed'},
-        {'title': 'third_most'},
-        {'title': 'second_most'},
-    ])],
-    indirect=['note_model'])
+    (FAKE_MANY_NOTES, 'tags', 'fake', {
+        'titles': ['fake_tag'],
+    }
+    ),
+    (FAKE_MANY_NOTES, 'notes', 'most', {
+        'titles': [
+            'most_viewed',
+            'third_most',
+            'second_most',
+        ],
+    }
+    )
+],
+    indirect=['note_model']
+)
 def test_search_notes(note_model, model_type, query, expected):
+    expected['books'] = ['general'] * 7
+    expected['tab_title'] = 'search'
     with patch('foolscap.note_display.display_list') as _mock:
         ctrl = Controller(model_type)
         ctrl.model = note_model
+        expected['model'] = note_model
         if model_type == 'tags':
             ctrl.model = TagsModel(note_model)
-
-        for item in expected:
-            item['model'] = ctrl.model
+            expected['model'] = ctrl.model
 
         ctrl.service_rules = ServiceRules(ctrl.model)
 
@@ -177,11 +200,11 @@ def test_search_notes(note_model, model_type, query, expected):
 @pytest.mark.parametrize("note_model_init, model_type", [
     (FAKE_SINGLE_NOTE, 'notes'),
     (FAKE_SINGLE_NOTE, 'tags'),
-    ], indirect=['note_model_init'])
+], indirect=['note_model_init'])
 def test_ctrl_search_output_with_no_results(note_model_init, model_type):
     ctrl = Controller(model_type)
     with patch('foolscap.meta_data.models.fuzzy_guess') as _fuzz,\
-         pytest.raises(SystemExit):
+            pytest.raises(SystemExit):
         ctrl.search_output('none')
         assert _fuzz.called_with('none', [])
 
@@ -312,7 +335,7 @@ def test_servicerule_last_viewed(note_model, notes, expected):
     assert result == expected
 
 
-@pytest.mark.parametrize("note_model, tags, expected",[
+@pytest.mark.parametrize("note_model, tags, expected", [
     (FOUR_FAKE_NOTES_TAGS, ['two', 'one', 'three'],
      ['one', 'two', 'three']),
 ], indirect=['note_model'])
@@ -325,26 +348,24 @@ def test_servicerule_by_count(note_model, tags, expected):
     assert result == expected
 
 
-@pytest.mark.parametrize("note_model, notes, tags",[
+@pytest.mark.parametrize("note_model, notes, tags", [
     (FAKE_SINGLE_NOTE_2, ['most_viewed'], ['fake_tag']),
 ], indirect=['note_model'])
 def test_servicerule_structure(note_model, notes, tags):
     service = ServiceRules(note_model)
     result = service.structure(notes)
-    assert result == [
-      {
-        'title': 'most_viewed',
+    assert result == {
+        'titles': ['most_viewed'],
         'model': note_model,
-      }
-    ]
+        'books': ['general'],
+    }
 
     from foolscap.meta_data import TagsModel
     tag_model = TagsModel(note_model)
     service = ServiceRules(tag_model)
     result = service.structure(tags)
-    assert result == [
-      {
-        'title': 'fake_tag',
-        'model': tag_model
-      }
-    ]
+    assert result == {
+        'titles': ['fake_tag'],
+        'model': tag_model,
+        'books': ['general']
+    }


### PR DESCRIPTION
This PR closes: #152 

Includes macro-tags in a tab bar.
We can also scroll through the macro tags.