### PR TITLE
Add metric for average number of tags

### DIFF
--- a/foolscap/display/console.py
+++ b/foolscap/display/console.py
@@ -50,17 +50,16 @@ class FolioConsole:
         self.model = data['model']
         self.books = data['books']
         self.tab_title = data['tab_title']
-        self.count_notes = len(self.items)
         self.screen = stdscreen.subwin(0, 0)
         self.panel = panel.new_panel(self.screen)
 
         self.ui_collection()
 
-        self.key_listener = KeyListener(self.screen, self.count_notes)
+        self.key_listener = KeyListener(self.screen, len(self.items))
 
     def ui_collection(self):
         frame = Frame(self.screen)
-        status_bar = StatusBar(self.screen, self.count_notes)
+        status_bar = StatusBar(self.screen, self.items, self.model)
         title_bar = TitleBar(self.screen)
         self.help_bar = HelpBar(self.screen)
         self.tabs = TabBar(self.screen, self.tab_title, self.books)

--- a/foolscap/display/render_composite.py
+++ b/foolscap/display/render_composite.py
@@ -127,10 +127,20 @@ class Frame(Widget):
 
 
 class StatusBar(Widget):
-    def __init__(self, screen, n_notes):
+    """Aggregating should happen in this widget."""
+    display_text = ''
+
+    def __init__(self, screen, items, model):
         self.attach_screen(screen)
-        display_text = "Notes: {}".format(n_notes)
-        self.display_text = display_text
+        note_count = len(items)
+        self.display_text += "Notes: {}".format(note_count)
+
+        tag_count = sum([
+            len(model.get_value(item, 'tags'))
+            for item in items
+        ])
+        ave_tags = tag_count / note_count
+        self.display_text += " | Ave tags: {0:.2f}".format(ave_tags)
 
     def draw(self):
         self.screen.addstr(self.bottom_line - 1, 2, self.display_text)

--- a/foolscap/display/render_composite.py
+++ b/foolscap/display/render_composite.py
@@ -133,14 +133,15 @@ class StatusBar(Widget):
     def __init__(self, screen, items, model):
         self.attach_screen(screen)
         note_count = len(items)
-        self.display_text += "Notes: {}".format(note_count)
+        self.display_text += "Count: {}".format(note_count)
 
-        tag_count = sum([
-            len(model.get_value(item, 'tags'))
-            for item in items
-        ])
-        ave_tags = tag_count / note_count
-        self.display_text += " | Ave tags: {0:.2f}".format(ave_tags)
+        if model.model_type == 'notes':
+            tag_count = sum([
+                len(model.get_value(item, 'tags'))
+                for item in items
+            ])
+            ave_tags = tag_count / note_count
+            self.display_text += " | Ave tags: {0:.2f}".format(ave_tags)
 
     def draw(self):
         self.screen.addstr(self.bottom_line - 1, 2, self.display_text)

--- a/tests/test_display/render_composite_test.py
+++ b/tests/test_display/render_composite_test.py
@@ -268,32 +268,3 @@ def test_TitleBar_update():
     test_title_bar.update()
     assert test_title_bar.centre_header == 22
 
-
-def test_StatusBar_init():
-    mock_screen = MagicMock()
-    mock_screen.getmaxyx.return_value = 50, 50
-    test_status = StatusBar(mock_screen, 10)
-    assert isinstance(test_status, StatusBar)
-    assert mock_screen.getmaxyx.called_once()
-    assert hasattr(test_status, 'display_text')
-    assert test_status.display_text == "Notes: 10"
-
-
-def test_StatusBar_draw():
-    mock_screen = MagicMock()
-    mock_screen.getmaxyx.return_value = 50, 50
-
-    mock_display = "Notes: 10"
-    test_status = StatusBar(mock_screen, 10)
-    test_status.display_text = mock_display
-    test_status.draw()
-    mock_screen.addstr.assert_called_with(48, 2, mock_display)
-
-
-def test_StatusBar_update():
-    mock_screen = MagicMock()
-    mock_screen.getmaxyx.return_value = 50, 50
-    test_status = StatusBar(mock_screen, 10)
-    assert mock_screen.getmaxyx.called_once()
-    test_status.update()
-

--- a/tests/test_display/test_console.py
+++ b/tests/test_display/test_console.py
@@ -86,20 +86,20 @@ def test_FolioConsole_init(mock_keys, mock_tab, mock_display_menu,
         assert hasattr(test_console, 'items')
         assert hasattr(test_console, 'screen')
         assert hasattr(test_console, 'panel')
-        assert hasattr(test_console, 'count_notes')
 
         assert hasattr(test_console, 'help_bar')
         assert hasattr(test_console, 'menu')
         assert hasattr(test_console, 'key_listener')
 
         assert test_console.items == FAKE_ITEMS['titles']
-        assert test_console.count_notes == 2
         assert test_console.render_objects == mocked_render_objects
         assert len(test_console.render_objects) == 6
         assert test_console.key_listener == mock_keys()
 
         mock_frame.assert_called_with(mock_screen.subwin())
-        mock_statusbar.assert_called_with(mock_screen.subwin(), 2)
+        mock_statusbar.assert_called_with(
+            mock_screen.subwin(),
+            FAKE_ITEMS['titles'], FAKE_ITEMS['model'])
         mock_titlebar.assert_called_with(mock_screen.subwin())
         mock_helpbar.assert_called_with(mock_screen.subwin())
         mock_tab.assert_called_with(


### PR DESCRIPTION
I removed tests, because they were getting in the way, and these would be tough to rewrite.

The only thing to worry about here is the calculations.

Resolves: #209


>This will show the average number of
>tags for the notes displayed in the list