### PR TITLE
FIX: foolscap to work on MacOS

### DIFF
--- a/foolscap/subprocess_utils.py
+++ b/foolscap/subprocess_utils.py
@@ -12,9 +12,9 @@ def edit_in_vim(open_file, add_cmds=None):
     :param str add_cmds: additional vim commands:
     """
     open_file.flush()
-    cmd = [EDITOR, open_file.name]
+    cmd = [EDITOR, "+set backupcopy=yes", open_file.name]
     if add_cmds:
-        cmd = [EDITOR, '-c', add_cmds, open_file.name]
+        cmd = [EDITOR, '-c', add_cmds, "+set backupcopy=yes", open_file.name]
 
     call(cmd)
 

--- a/tests/subprocess_utils_test.py
+++ b/tests/subprocess_utils_test.py
@@ -7,25 +7,22 @@ from foolscap import subprocess_utils
 
 
 class FileObject(MagicMock):
-
     @property
     def name(self):
         return 'note.txt'
 
 
-@pytest.mark.parametrize("cmds, expected",
-    [
-        (None, ['vim', 'note.txt']),
-        (
-            ':set textwidth=30',
-            ['vim', '-c', ':set textwidth=30', 'note.txt'],
-        )
-    ]
-)
-def test_edit_in_vim(cmds, expected):
+@pytest.mark.parametrize(
+    "case, expected",
+    [(None, ['vim', '+set backupcopy=yes', 'note.txt']),
+     (
+         ':set textwidth=30',
+         ['vim', '-c', ':set textwidth=30', '+set backupcopy=yes', 'note.txt'],
+     )])
+def test_edit_in_vim(case, expected):
     _file = FileObject()
     with patch('foolscap.subprocess_utils.call') as mock_call:
-        subprocess_utils.edit_in_vim(_file, add_cmds=cmds)
+        subprocess_utils.edit_in_vim(_file, add_cmds=case)
 
     mock_call.assert_called_with(expected)
     assert _file.mock_calls == [call.flush()]


### PR DESCRIPTION
    I work on Mac, so now foolscap does too.
    One thing I haven't fixed is locking down the process
    to run a single instance at a time. I haven't figured this
    out on Mac. The Linux abstract port binding still works
    on Linux.